### PR TITLE
Pr/calculation layers

### DIFF
--- a/src/java/application/GraphRegister.java
+++ b/src/java/application/GraphRegister.java
@@ -15,7 +15,7 @@ public class GraphRegister
 
     private static final GraphRegister instance_self = new GraphRegister();
 
-    private TreeMap<Graph, java.awt.Point[]> map_graphs_to_points = new TreeMap<Graph, java.awt.Point[]>();
+    private TreeMap<Graph, int[][]> map_graphs_to_points = new TreeMap<Graph, int[][]>();
     private int WIDTH;
     private int HEIGHT;
 
@@ -49,10 +49,10 @@ public class GraphRegister
 
     public void remove_graph(int id)
     {
-        for (Iterator<Entry<Graph, java.awt.Point[]>> entry_it = map_graphs_to_points.entrySet().iterator();
+        for (Iterator<Entry<Graph, int[][]>> entry_it = map_graphs_to_points.entrySet().iterator();
                 entry_it.hasNext();)
         {
-            Entry<Graph, java.awt.Point[]> entry = entry_it.next();
+            Entry<Graph, int[][]> entry = entry_it.next();
             if (entry.getKey().get_ID() == id)
             {
                 entry_it.remove();
@@ -100,7 +100,7 @@ public class GraphRegister
 
     public void calculate_points(int id)
     {
-        for(Entry<Graph, java.awt.Point[]> entry : map_graphs_to_points.entrySet())
+        for(Entry<Graph, int[][]> entry : map_graphs_to_points.entrySet())
         {
             if (entry.getKey().get_ID() == id)
             {
@@ -111,23 +111,24 @@ public class GraphRegister
         update_window();
     }
 
-    private java.awt.Point[] calculate_points(Graph graph)
+    private int[][] calculate_points(Graph graph)
     {
         System.out.println("GraphRegister is calculating...");
         graph.calculate_points((double)width_x, (double)height_y, 1000, Point.of(0,0));
         Point[] arr_pts = graph.get_points();
-        java.awt.Point[] arr_awt_pts = new java.awt.Point[arr_pts.length];
+        int[][] arr_values = new int[2][arr_pts.length];
 
         for (int i = 0; i < arr_pts.length; i++)
         {
             Point p = arr_pts[i];
-            arr_awt_pts[i] = new java.awt.Point((int)(p.get_x()/width_x*WIDTH + WIDTH/2), (int)(-p.get_y()/height_y*HEIGHT + HEIGHT/2));
+            arr_values[0][i] = (int)(p.get_x()/width_x*WIDTH + WIDTH/2);
+            arr_values[1][i] = (int)(-p.get_y()/height_y*HEIGHT + HEIGHT/2);
         }
-        return arr_awt_pts;
+        return arr_values;
     }
 
 
-    public Iterable<java.awt.Point[]> get_values()
+    public Iterable<int[][]> get_values()
     {
         return map_graphs_to_points.values();
     }

--- a/src/java/application/GraphViewPort.java
+++ b/src/java/application/GraphViewPort.java
@@ -67,12 +67,9 @@ public class GraphViewPort extends JPanel
 
     public void paint_graphs(Graphics g)
     {
-        for (Point[] arr_points : GraphRegister.get().get_values())
+        for (int[][] arr_values : GraphRegister.get().get_values())
         {
-            for(int i = 1; i< arr_points.length; i++)
-            {
-                g.drawLine(arr_points[i-1].x, arr_points[i-1].y, arr_points[i].x, arr_points[i].y);
-            }
+            g.drawPolyline(arr_values[0], arr_values[1], arr_values[1].length);
         }
     }
 

--- a/src/java/automaton/CalculationBuilder.java
+++ b/src/java/automaton/CalculationBuilder.java
@@ -38,7 +38,8 @@ public final class CalculationBuilder
         func = func.replaceAll("\\s","");
         final char[] arr_char = func.toCharArray();
         Node node = build(arr_char, 0,arr_char.length);
-        node.cut_reduntant_calculations();
+        node = node.cut_reduntant_calculations();
+        node = node.align_same_binding_strengths();
         return node;
     }
 
@@ -54,6 +55,7 @@ public final class CalculationBuilder
      * @param chars
      * @param begin
      * @param end
+
      * @return
      *  - Node -> Node is a tree, in which the whole interval is sorted recursively to create an
      *            accurate result, simulating proper mathematics.
@@ -106,6 +108,7 @@ public final class CalculationBuilder
      * @param end
      * @param arr_types
      * @param binding_strength
+     *
      * @return
      *  - Optional.of(Node) -> Node is a tree, in which the whole interval is sorted recursively to
      *                         generate a mathematically accurate result.
@@ -150,7 +153,6 @@ public final class CalculationBuilder
                     return Optional.of(build(chars, begin + 2, end - 1));
                 }
             }
-
         }
         Node a, b;
         ///
@@ -219,12 +221,14 @@ public final class CalculationBuilder
         return Optional.empty();
     }
 
+
     /**
      * Returns the index, at which this bracket closes.
      *
      * @param chars
      * @param begin
      * @param end
+     *
      * @return
      */
     private static int find_end_bracket(final char[] chars, int begin, int end)
@@ -318,6 +322,7 @@ public final class CalculationBuilder
     /**
      *
      * @param c
+     *
      * @return
      */
     private static boolean char_is_decimal_point_divider(char c)
@@ -337,6 +342,7 @@ public final class CalculationBuilder
      * Test, if the char given as parameter is a sign (+/-) symbol.
      *
      * @param c
+     *
      * @return
      * 1 - char is a positive sign '+'
      * -1 - char is a negative sign '-'
@@ -360,6 +366,7 @@ public final class CalculationBuilder
      *
      *
      * @param c
+     *
      * @return
      */
     private static CalculationType read_operator(char c)

--- a/src/java/automaton/Function.java
+++ b/src/java/automaton/Function.java
@@ -1,0 +1,46 @@
+package src.java.automaton;
+
+import src.java.automaton.datatree.Node;
+
+/**
+ * Wrapper class for the calculations.
+ *
+ */
+public class Function
+{
+    Node top_node;
+
+    private Function(String function)
+    {
+        top_node = CalculationBuilder.build(function);
+    }
+
+    public static Function of(String function)
+    {
+        return new Function(function);
+    }
+
+    public double get(double X)
+    {
+        return top_node.get(X);
+    }
+
+    @Override
+    public String toString()
+    {
+        return top_node.toString();
+    }
+
+    public boolean equals_func(Function func)
+    {
+        if (func.top_node.equals_node(top_node))
+        {
+            return true;
+        }
+        return false;
+    }
+
+    /// TODO equivalence tests
+    /// TODO Function Types (Constants, linear functions, Polynomials, etc.)
+    /// useful to reduce calculations (constants and linear functions only require 2 points)
+}

--- a/src/java/automaton/datatree/Calculation.java
+++ b/src/java/automaton/datatree/Calculation.java
@@ -82,18 +82,19 @@ public class Calculation implements Node
 
 
     @Override
-    public void cut_reduntant_calculations()
+    public Node cut_reduntant_calculations()
     {
+        if (!a.contains_X() && !b.contains_X())
+        {
+            return Value.of(get(0));
+        }
         /// We check for instances of Calculations, because else we would be replacing each Value instance with
         /// a new Value instance, which just creates unnecessary work for the GC.
         if (a instanceof Calculation)
         {
             /// a contains X -> search for possible cuts recursively (DFS) down the tree
-            if (a.contains_X())
-            {
-                a.cut_reduntant_calculations();
-            }
-            else
+            a.cut_reduntant_calculations();
+            if (!a.contains_X())
             {
                 /// a does not contains X -> replace a with Value of a.
                 /// X can be set to anything here
@@ -105,18 +106,15 @@ public class Calculation implements Node
         if (b instanceof Calculation)
         {
             /// b contains X -> search for possible cuts recursively (DFS) down the tree
-            if (b.contains_X())
-            {
-                b.cut_reduntant_calculations();
-            }
-            else
+            b.cut_reduntant_calculations();
+            if (!b.contains_X())
             {
                 /// b does not contains X -> replace b with Value of b.
                 /// X can be set to anything here
                 b = Value.of(b.get(0));
             }
         }
-
+        return this;
     }
 
 
@@ -126,6 +124,76 @@ public class Calculation implements Node
         if (a.contains_X() || b.contains_X())
         {
             return true;
+        }
+        return false;
+    }
+
+
+    @Override
+    public Node align_same_binding_strengths()
+    {
+        if (a instanceof Calculation calc)
+        {
+            if (calc.type == type)
+            {
+                return CalculationLayer.of(type)
+                        .add(calc.a)
+                        .add(calc.b)
+                        .add(b)
+                    .align_same_binding_strengths();
+            }
+        }
+        if (b instanceof Calculation calc)
+        {
+            if (calc.type == type)
+            {
+                return CalculationLayer.of(type)
+                        .add(a)
+                        .add(calc.a)
+                        .add(calc.b)
+                    .align_same_binding_strengths();
+            }
+        }
+
+        a = a.align_same_binding_strengths();
+        b = b.align_same_binding_strengths();
+        return this;
+    }
+
+
+    public Node get_a()
+    {
+        return a;
+    }
+
+
+    public Node get_b()
+    {
+        return b;
+    }
+
+
+    public CalculationType get_type()
+    {
+        return type;
+    }
+
+
+    @Override
+    public String toString()
+    {
+        return a.toString()+CalculationType.get_char(type)+b.toString();
+    }
+
+    public boolean equals_node(Node node)
+    {
+        if (node instanceof Calculation calc)
+        {
+            if (a.equals(calc.a) && b.equals(calc.b))
+            {
+                return true;
+            }
+            return false;
         }
         return false;
     }

--- a/src/java/automaton/datatree/CalculationLayer.java
+++ b/src/java/automaton/datatree/CalculationLayer.java
@@ -1,0 +1,280 @@
+package src.java.automaton.datatree;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+import src.java.global.Config;
+
+public class CalculationLayer implements Node
+{
+
+    private LinkedList<Node> ll_nodes;
+    private final CalculationType type;
+    //TODO add inverse parameter & function and remove subtraction, division, etc...
+
+
+    private CalculationLayer(CalculationType type)
+    {
+        System.out.println("CALCULATION LAYER CREATED");
+        ll_nodes = new LinkedList<Node>();
+        if (type == null)
+        {
+            throw new NullPointerException("CalculationType cannot be null!");
+        }
+        this.type = type;
+    }
+
+
+    public CalculationLayer add(Node node)
+    {
+        if (node == null)
+        {
+            throw new NullPointerException("Nodes cannot be null!");
+        }
+        ll_nodes.add(node);
+        return this;
+    }
+
+
+    public CalculationLayer addAll(List<Node> nodes)
+    {
+        ll_nodes.addAll(nodes);
+        return this;
+    }
+
+
+    public static CalculationLayer of(CalculationType type)
+    {
+        return new CalculationLayer(type);
+    }
+
+
+    @Override
+    public double get(double X)
+    {
+        return get(X, true);
+    }
+
+
+    @Override
+    public double get(double X, boolean log)
+    {
+        return get(this.ll_nodes, this.type, X, log);
+    }
+
+
+    @SuppressWarnings("unused")
+    private static double get(LinkedList<Node> ll_nodes, CalculationType type, double X, boolean log)
+    {
+        if (log && Config.LOG_CALCULATION_STATE)
+        {
+            System.out.print("requesting value from calculation...: ");
+        }
+        double value;
+        switch (type)
+        {
+            case ADDITION ->
+            {
+                value = 0;
+                for (Node node : ll_nodes)
+                {
+                    value += node.get(X, true);
+                    System.out.print(node.get(X, false) + ", ");
+                }
+                break;
+            }
+            case SUBTRACTION ->
+            {
+                Iterator<Node> iterator = ll_nodes.iterator();
+                value = iterator.next().get(X, true);
+                while(iterator.hasNext())
+                {
+                    Node node = iterator.next();
+                    value += -node.get(X, true);
+                    System.out.print(node.get(X, false) + ", ");
+                }
+                break;
+            }
+            case MULTIPLICATION ->
+            {
+                Iterator<Node> iterator = ll_nodes.iterator();
+                value = 1;
+                while(iterator.hasNext())
+                {
+                    Node node = iterator.next();
+                    value *= node.get(X, true);
+                    System.out.print(node.get(X, false) + ", ");
+                }
+                break;
+            }
+            case DIVISION ->
+            {
+                Iterator<Node> iterator = ll_nodes.iterator();
+                value = iterator.next().get(X);
+                while(iterator.hasNext())
+                {
+                    Node node = iterator.next();
+                    value /= node.get(X, true);
+                    System.out.print(node.get(X, false) + ", ");
+                }
+                break;
+            }
+            case POWER ->
+            {
+                Iterator<Node> iterator = ll_nodes.iterator();
+                value = Math.pow(iterator.next().get(X, true), iterator.next().get(X, true));
+                if (iterator.hasNext())
+                {
+                    System.out.println("Power nodes shouldn't have more than 2 nodes...");
+                }
+                break;
+            }
+            default -> throw new AssertionError();
+        }
+        System.out.println("type = " + type);
+        return value;
+    }
+
+
+    //TODO it should cut Values, like Value.of(0) in addition or Value.of(1) in Multiplication
+    @Override
+    public Node cut_reduntant_calculations()
+    {
+        LinkedList<Node> ll_nodes_without_x = new LinkedList<Node>();
+        /// We check for instances of Calculations, because else we would be replacing each Value instance with
+        /// a new Value instance, which just creates unnecessary work for the GC.
+        Iterator<Node> iterator = ll_nodes.iterator();
+        while(iterator.hasNext())
+        {
+            Node node = iterator.next();
+            if (node instanceof CalculationLayer)
+            {
+                /// search for possible cuts recursively (DFS) down the tree
+                node = node.cut_reduntant_calculations();
+                if (!node.contains_X())
+                {
+                    /// node does not contains X -> replace node with Value of node.
+                    /// X can be set to anything here
+                    node = Value.of(node.get(0));
+                    ll_nodes_without_x.add(node);
+                    iterator.remove();
+                }
+            }
+        }
+        Node value = Value.of(get(ll_nodes_without_x, this.type, 0, false));
+        if (ll_nodes.size() == 0)
+        {
+            return value;
+        }
+        return this.add(value);
+    }
+
+
+    @Override
+    public boolean contains_X()
+    {
+        for (Node node : ll_nodes)
+        {
+            if (node.contains_X())
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    @Override
+    public Node align_same_binding_strengths()
+    {
+        LinkedList<Node> ll_nodes_new = new LinkedList<Node>();
+        for (Node node : ll_nodes)
+        {
+            ll_nodes_new.add(node.align_same_binding_strengths());
+        }
+        ll_nodes.clear();
+        ll_nodes.addAll(ll_nodes_new);
+
+        Iterator<Node> iterator = ll_nodes.iterator();
+        while(iterator.hasNext())
+        {
+            Node node = iterator.next();
+            if (node instanceof CalculationLayer calc)
+            {
+                if (calc.type == type)
+                {
+                    int index = ll_nodes.indexOf(calc);
+                    ll_nodes.remove(index);
+                    ll_nodes.addAll(index, calc.ll_nodes);
+                    iterator = ll_nodes.iterator();
+                    for (int i = 0; i < index-1; i++)
+                    {
+                        iterator.next();
+                    }
+                }
+            }
+            else if (node instanceof Calculation calc)
+            {
+                if (calc.get_type() == type)
+                {
+                    int index = ll_nodes.indexOf(node);
+                    ll_nodes.remove(index);
+                    ll_nodes.add(index, calc.get_b());
+                    ll_nodes.add(index, calc.get_a());
+                    iterator = ll_nodes.iterator();
+                    for (int i = 0; i < index-1; i++)
+                    {
+                        iterator.next();
+                    }
+                }
+            }
+        }
+        return this;
+    }
+
+
+    @Override
+    public boolean equals_node(Node node)
+    {
+        if (node instanceof CalculationLayer layer)
+        {
+            Iterator<Node> iterator_i = ll_nodes.iterator();
+            Iterator<Node> iterator_ii = layer.ll_nodes.iterator();
+            while(iterator_i.hasNext() && iterator_ii.hasNext())
+            {
+                if (!iterator_i.next().equals_node(iterator_ii.next()))
+                {
+                    return false;
+                }
+            }
+            /// one has more nodes...
+            if (iterator_i.hasNext() || iterator_ii.hasNext())
+            {
+                return false;
+            }
+            return true;
+        }
+        return false;
+    }
+
+
+    @Override
+    public String toString()
+    {
+        String s = "";
+
+        Iterator<Node> iterator = ll_nodes.iterator();
+        while(iterator.hasNext())
+        {
+            Node node = iterator.next();
+            s = s + node.toString();
+            if (iterator.hasNext())
+            {
+                s = s + CalculationType.get_char(type);
+
+            }
+        }
+        return s;
+    }
+}

--- a/src/java/automaton/datatree/Node.java
+++ b/src/java/automaton/datatree/Node.java
@@ -17,6 +17,7 @@ public abstract interface Node
     public double get(double X);
 
 
+
     /**
      * Cuts all calculations, which do not require the x-parameter.
      * These are supposed to be replaced by Value instances of
@@ -24,7 +25,20 @@ public abstract interface Node
      *
      *
      */
-    public void cut_reduntant_calculations();
+    public Node cut_reduntant_calculations();
+
+
+    /**
+     * Pulls nodes, which have the same binding strength
+     * up into a single Calculation node.
+     *
+     * This way a node structure, like:
+     * a+(b+(c+d))
+     * would result in:
+     * a+b+c+d
+     *
+     */
+    public Node align_same_binding_strengths();
 
 
     /**
@@ -35,5 +49,7 @@ public abstract interface Node
      */
     public boolean contains_X();
 
+
+    public boolean equals_node(Node node);
 
 }

--- a/src/java/automaton/datatree/Value.java
+++ b/src/java/automaton/datatree/Value.java
@@ -60,11 +60,53 @@ public class Value implements Node
     @Override
     public boolean contains_X()
     {
-        return X_VALUE.equals(this);
+        /// Has to compare adresses. Since equals() may be shadowed at some point,
+        /// this ensures that won't become a problem.
+        /// value.equals(X_VALUE) => loop => overflow
+        return super.equals(X_VALUE);
     }
 
 
     @Override
-    public void cut_reduntant_calculations() {}
+    public Node cut_reduntant_calculations()
+    {
+        return this;
+    }
+
+
+    @Override
+    public Node align_same_binding_strengths()
+    {
+        return this;
+    }
+
+    @Override
+    public String toString()
+    {
+        return Double.toString(value);
+    }
+
+    @Override
+    public boolean equals_node(Node node)
+    {
+        if (node instanceof Value val)
+        {
+            if (this.contains_X() && val.contains_X())
+            {
+                return true;
+            }
+            else if (this.contains_X() || val.contains_X())
+            {
+                return false;
+            }
+            if (val.value == this.value)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
 
 }

--- a/src/java/functions/Graph.java
+++ b/src/java/functions/Graph.java
@@ -2,20 +2,19 @@ package src.java.functions;
 
 import java.util.TreeSet;
 
-import src.java.automaton.CalculationBuilder;
-import src.java.automaton.datatree.Node;
+import src.java.automaton.Function;
 
 public class Graph implements Comparable<Graph>
 {
 
-    private Node top_node;
+    private Function function;
     private TreeSet<Point> set_points;
     private int ID;
 
     public Graph(String function, int ID)
     {
         this.ID = ID;
-        top_node = CalculationBuilder.build(function);
+        set_function(function);
         set_points = new TreeSet<Point>();
     }
 
@@ -25,9 +24,10 @@ public class Graph implements Comparable<Graph>
     }
 
 
-    public void set_function(String function)
+    public String set_function(String function)
     {
-        top_node = CalculationBuilder.build(function);
+        this.function = Function.of(function);
+        return function.toString();
     }
 
 
@@ -44,7 +44,7 @@ public class Graph implements Comparable<Graph>
         boolean last_point_accepted = false;
         for (double x = x_begin; x < x_end; x+=diff_x)
         {
-            double y = top_node.get(x);
+            double y = function.get(x);
             if (Double.isNaN(y))
             {
                 last_point_accepted = false;
@@ -57,7 +57,7 @@ public class Graph implements Comparable<Graph>
                 /// this ensures the edges aren't empty
                 if (last_point_accepted == false)
                 {
-                    double y_val = top_node.get(x-diff_x);
+                    double y_val = function.get(x-diff_x);
                     if (!Double.isNaN(y_val))
                     {
                         Point p = Point.of(x-diff_x, y_val);

--- a/src/tests/CalculationBuilderTests.java
+++ b/src/tests/CalculationBuilderTests.java
@@ -370,6 +370,7 @@ public class CalculationBuilderTests
 
         //TODO negative sign is calculated with the bracket, before it is squared.
         func = "-(x-25)^2+14";
+        //func = "(-1)*(x-25)^2+14";
         System.out.println("begin testing.:" + func);
         tree = CalculationBuilder.build(func);
         value = tree.get(-3.0);

--- a/src/tests/CalculationLayerTests.java
+++ b/src/tests/CalculationLayerTests.java
@@ -1,0 +1,58 @@
+package src.tests;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import src.java.automaton.datatree.Calculation;
+import src.java.automaton.datatree.CalculationLayer;
+import src.java.automaton.datatree.CalculationType;
+import src.java.automaton.datatree.Node;
+import src.java.automaton.datatree.Value;
+
+
+public class CalculationLayerTests
+{
+
+    private double av, bv, xv;
+    private Node a, b, c;
+
+
+    private void change_values(double a, double b, double x)
+    {
+        this.av = a;
+        this.bv = b;
+        this.xv = x;
+
+        this.a = Value.of(av);
+        this.b = Value.of(bv);
+    }
+
+    @Test
+    public void align_same_binding_strengths()
+    {
+        CalculationType type = CalculationType.ADDITION;
+        change_values(12.0, 13.0, 3.0);
+        c = Calculation.of(Calculation.of(a, b, type), Calculation.of(a, b, type), type);
+        c = c.align_same_binding_strengths();
+        CalculationLayer expect = CalculationLayer.of(type).add(a).add(b).add(a).add(b);
+        System.out.println(expect.toString());
+        System.out.println(c.toString());
+        assertTrue(expect.equals_node(c));
+    }
+
+    @Test
+    public void cut_reduntant_calculations()
+    {
+        CalculationType type = CalculationType.ADDITION;
+        change_values(12.0, 13.0, 3.0);
+        c = Calculation.of(Calculation.of(a, b, type), Calculation.of(a, b, type), type);
+        c = c.cut_reduntant_calculations();
+        c = c.align_same_binding_strengths();
+        Value expect = Value.of(12+13+12+13);
+        System.out.println(expect.toString());
+        System.out.println(c.toString());
+        assertTrue(expect.equals_node(c));
+
+    }
+}

--- a/src/tests/CalculationTests.java
+++ b/src/tests/CalculationTests.java
@@ -225,6 +225,7 @@ public class CalculationTests
     public void cut_redundant_nodes()
     {
         ///TODO this requires some sort of accessibility functionality
-
     }
+
+
 }


### PR DESCRIPTION
## Algorithm changes
### added new CalculationLayer class:
CalculationLayer instances are used to reduce the depth of the node-tree used for functions. Later this may be useful for more complicated features

### align_same_binding_strengths()
- CalculationLayer is created, when a Calculation instance has the same calculation-type, as it's child nodes

### cut_redundant_calculations()
- will now return Value instances, if the calculation itself is redundant


## Misc changes:
- added new Function wrapper classes
- removed java.awt.Point dependency
- GraphViewPort draws using PolyLine now